### PR TITLE
Print output to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	fe := filterEventsForTime(events, startTime)
 	oe := organizeEvents(fe)
 	md := oe.markdown()
-	log.Print("\n" + md)
+	fmt.Println(md)
 }
 
 func oauthClient() *http.Client {


### PR DESCRIPTION
The default logger prints to stderr. Separating the snippet output from log messages makes redirecting to the copy buffer easy, e.g.

```sh
./github-snippets | pbcopy
```

(or `xclip` for linux)